### PR TITLE
update id in new-listing.js, adjust favicon link, add preventdefault …

### DIFF
--- a/public/js/cloudinary.js
+++ b/public/js/cloudinary.js
@@ -13,6 +13,7 @@ const myWidget = cloudinary.createUploadWidget(
     }
   });
 
-document.getElementById("upload_widget").addEventListener("click", function () {
+document.getElementById("upload_widget").addEventListener("click", function (e) {
+  e.preventDefault();
   myWidget.open();
 }, false);

--- a/public/js/new-listing.js
+++ b/public/js/new-listing.js
@@ -5,7 +5,7 @@ const listingFormHandler = async (event) => {
     const category = document.querySelector('#category').value;
     const cost = document.querySelector('#cost').value;
     const availability = document.querySelector('input[name="availability"]:checked').value;
-    const filename = document.querySelector('#filename').value;
+    const filename = document.querySelector('#uploadedimage').value;
     const community_id = document.querySelector('#community_id').value;
   
     if (material_name && description && category && cost && availability && community_id) {

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -8,7 +8,7 @@
   <!-- Include your public style sheet -->
   <link href="./css/style.css" rel="stylesheet">
   <title>ShareSphere Main Page</title>
-  <link rel="icon" type="image/x-icon" href="./images/favicon-light.ico">
+  <link rel="icon" type="image/x-icon" href="/images/favicon-light.ico">
 </head>
 
 <body>


### PR DESCRIPTION
…to cloudinary widget

new listing creation should work again.
the prevent default should allow the widget to be opened without auto closing/submitting the entire form.
previously the favicon wouldn't appear when on community pages, now it should appear on all pages.